### PR TITLE
Ensure Go standards via `gofmt` and `go mod tidy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,32 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dist: bionic
+VERB = @
+ifeq ($(VERBOSE),1)
+	VERB =
+endif
 
-language: go
+gofmt:
+	$(VERB) find . -name '*.go' | xargs -I {} gofmt -s -w {}
 
-go:
-  - "1.12.x"
-  - "1.13.x"
-  - "1.14.x"
+gofmt_test:
+	$(VERB) echo "Running 'go fmt' test ..."
+	$(VERB) ./gofmt_test.sh
 
-os:
-  - linux
-  - osx
+go_mod_tidy_test:
+	$(VERB) echo "Running 'go mod tidy' test ..."
+	$(VERB) ./go_mod_tidy_test.sh
 
-env:
-  - GO111MODULE=on
-
-branches:
-  only:
-    - master
-
-matrix:
-  allow_failures:
-    - os: osx
-
-  fast_finish: true
-
-script:
-  - go build ./...
-  - make test VERBOSE=1
+test: gofmt_test go_mod_tidy_test

--- a/collections/docs-list/dynamic/server/server.go
+++ b/collections/docs-list/dynamic/server/server.go
@@ -35,7 +35,7 @@ var (
 	webRoot = flag.String("web-root", cwd, "Root of the web file tree.")
 	host    = flag.String("host", "127.0.0.1", "By default, the server is only accessible via localhost. "+
 		"Set to 0.0.0.0 or empty string to open to all.")
-	port               = flag.String("port", getEnvWithDefault("PORT", "8080"), "Port to listen on; $PORT env var overrides default value.")
+	port = flag.String("port", getEnvWithDefault("PORT", "8080"), "Port to listen on; $PORT env var overrides default value.")
 	tofu *soyhtml.Tofu
 )
 

--- a/go_mod_tidy_test.sh
+++ b/go_mod_tidy_test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -u
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that we have run `go mod tidy` to keep our modules config clean.
+
+declare -r GO_MOD="go.mod"
+declare -r GO_SUM="go.sum"
+
+declare -r GO_MOD_ORIG="go.mod.orig"
+declare -r GO_SUM_ORIG="go.sum.orig"
+
+declare -i success=0
+
+cp "${GO_MOD}" "${GO_MOD_ORIG}"
+cp "${GO_SUM}" "${GO_SUM_ORIG}"
+
+go mod tidy
+
+diff -u "${GO_MOD}" "${GO_MOD_ORIG}" || success=1
+diff -u "${GO_SUM}" "${GO_SUM_ORIG}" || success=1
+
+mv "${GO_MOD_ORIG}" "${GO_MOD}"
+mv "${GO_SUM_ORIG}" "${GO_SUM}"
+
+if [[ ${success} == 0 ]]; then
+  echo PASSED
+else
+  echo FAILED
+fi
+exit ${success}

--- a/gofmt_test.sh
+++ b/gofmt_test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -u
+#
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies that all *.go files are formatted according to `gofmt -s`.
+
+declare -r VERBOSE="${VERBOSE:-}"
+
+declare -i global_status=0
+declare -i local_status=0
+
+declare -i num_files_passed=0
+declare -i num_files_failed=0
+
+for gosrc in `find . -name \*\.go`; do
+  if [[ "${VERBOSE}" -eq 1 ]]; then
+    diff -u "${gosrc}" <(gofmt -s "${gosrc}")
+  else
+    diff -u "${gosrc}" <(gofmt -s "${gosrc}") > /dev/null 2>&1
+  fi
+  local_status=$?
+  if [[ ${local_status} != 0 ]]; then
+    echo "failed: ${gosrc}"
+    global_status=${local_status}
+    num_files_failed=$((num_files_failed + 1))
+  else
+    num_files_passed=$((num_files_passed + 1))
+  fi
+done
+
+echo "gofmt files passed: ${num_files_passed} / $((num_files_passed + num_files_failed))"
+exit ${global_status}


### PR DESCRIPTION
* add `Makefile` with `gofmt` target to ensure all Go source code is formatted
  via `gofmt -s`
* add `gofmt_test.sh` to ensure that all code is already formatted, and which
  fails if it's not
* add `go_mod_tidy_test.sh` to ensure that `go.mod` and `go.sum` have been
  recently cleaned up with `go mod tidy`
* add `make test` target to run the above tests, and add it to `.travis.yml` to
  ensure that these tests are always run automatically for every PR and on the
  `master` branch

This also fixes the finding in
https://goreportcard.com/report/github.com/mbrukman/notebook#gofmt
which refers to
https://github.com/mbrukman/notebook/blob/29a510904ba857cd5958e5d82b391298c7154b61/collections/docs-list/dynamic/server/server.go#L38