### PR TITLE
Add static build of web app

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERB = @
+ifeq ($(VERBOSE), 1)
+	VERB =
+endif
+
+PORT = 5000
+
+node-build:
+	$(VERB) yarn run build
+
+py-serve:
+	$(VERB) python -m http.server --bind 127.0.0.1 --directory build $(PORT)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "preact-cli": "^3.0.5",
+    "preact-render-to-string": "^5.1.16",
     "typescript": "^4.1.5"
   }
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6288,6 +6288,13 @@ preact-cli@^3.0.5:
     workbox-strategies "^5.1.3"
     workbox-webpack-plugin "^5.1.3"
 
+preact-render-to-string@^5.1.16:
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.16.tgz#379db30e51916d45a67c00163ef812ad376aa721"
+  integrity sha512-HvO3W29Sziz9r5FZGwl2e34XJKzyRLvjhouv3cpkCGszNPdnvkO8p4B6CBpe0MT/tzR+QVbmsAKLrMK222UXew==
+  dependencies:
+    pretty-format "^3.8.0"
+
 preact@^10.5.12:
   version "10.5.12"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.12.tgz#6a8ee8bf40a695c505df9abebacd924e4dd37704"
@@ -6325,6 +6332,11 @@ pretty-error@^2.0.2:
   dependencies:
     lodash "^4.17.20"
     renderkid "^2.0.4"
+
+pretty-format@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+  integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This consists of two commits:

* add package `preact-render-to-string` to enable static building of web app via `preact build`
* add demo: Node web app build + Python static web server

This shows that we can develop and build the app with Preact, and then serve it without using Node, e.g., using Python or Go. Thus, if we build an API server in a different language, we won't need to run two servers, which decreases our deployment complexity quite a bit.