### PR TITLE
Add a proxy to mimic prod deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 *~
 *.sw?
 
+# Go binaries
+web/proxy/proxy
+web/server/server
+
 # Node build outputs
 web/ui/build/
 web/ui/node_modules/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
   "files.exclude": {
     "**/*.sw?": true,
     "**/*~": true,
+    "web/proxy/proxy": true,
+    "web/server/server": true,
     "web/ui/build": true,
     "web/ui/node_modules": true,
     "web/ui/size-plugin.json": true

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/mbrukman/notebook
 
 go 1.12
+
+require (
+	github.com/ghodss/yaml v1.0.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/web/proxy/Makefile
+++ b/web/proxy/Makefile
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERB = @
+
+ifeq ($(VERBOSE),1)
+	VERB =
+endif
+
+GO_SRCS := $(shell find . -name '*.go')
+PORT = 7000
+
+proxy: $(GO_SRCS)
+	$(VERB) go build .
+
+run: proxy
+	$(VERB) ./proxy -config config.yaml -port $(PORT)

--- a/web/proxy/config.yaml
+++ b/web/proxy/config.yaml
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Configuration overview:
+#
+# * entries are evaluated in the order they're listed in this file
+# * `path` is literal URL path prefix
+# * `target` includes the protocol, host, and port
+
+routes:
+  - path: /api/
+    target: http://localhost:5000
+  - path: /
+    target: http://localhost:8080

--- a/web/proxy/proxy.go
+++ b/web/proxy/proxy.go
@@ -1,0 +1,137 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+var (
+	host = flag.String("host", "127.0.0.1", "Host to listen on; 127.0.0.1 only allows connections "+
+		"from localhost; set to 0.0.0.0 or empty to allow external connetions.")
+	port       = flag.Int("port", 9000, "Port to listen on")
+	configFile = flag.String("config", "", "Config file, either YAML (*.yaml, *.yml) or JSON (*.json) format.")
+)
+
+type Route struct {
+	Path   string `yaml:"path" json:"path"`
+	Target string `yaml:"target" json:"target"`
+}
+
+type ProxyConfig struct {
+	Routes []Route `yaml:"routes" json:"routes"`
+}
+
+type ConfigError struct {
+	Message string
+}
+
+func (ce *ConfigError) Error() string {
+	return ce.Message
+}
+
+func ParseConfig(filename string) (*ProxyConfig, error) {
+	if filename == "" {
+		return nil, &ConfigError{
+			Message: "Config filename must be specified (provided empty string)",
+		}
+	}
+
+	data, readErr := ioutil.ReadFile(filename)
+	if readErr != nil {
+		return nil, &ConfigError{
+			Message: fmt.Sprintf("Error reading file %s: %v", filename, readErr),
+		}
+	}
+
+	config := &ProxyConfig{}
+	if strings.HasSuffix(*configFile, "yaml") || strings.HasSuffix(*configFile, ".yml") {
+		yamlErr := yaml.Unmarshal(data, config)
+		if yamlErr != nil {
+			return nil, &ConfigError{
+				Message: fmt.Sprintf("Error parsing YAML: %v", yamlErr),
+			}
+		}
+	} else if strings.HasSuffix(*configFile, ".json") {
+		jsonErr := json.Unmarshal(data, config)
+		if jsonErr != nil {
+			return nil, &ConfigError{
+				Message: fmt.Sprintf("Error parsing JSON: %v", jsonErr),
+			}
+		}
+	} else {
+		return nil, &ConfigError{
+			Message: fmt.Sprintf("Unrecognized file suffix (only YAML and JSON are supported): %s\n", *config),
+		}
+	}
+	return config, nil
+}
+
+type Proxy struct {
+	Backends map[string]*httputil.ReverseProxy
+}
+
+func (proxy *Proxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	log.Printf("Incoming request: %s", req.URL.Path)
+	for path, backend := range proxy.Backends {
+		if strings.HasPrefix(req.URL.Path, path) {
+			log.Printf("Redirecting %s\n", req.URL.Path)
+			backend.ServeHTTP(rw, req)
+			return
+		}
+	}
+	log.Printf("Error: unhandled request (no backend mapping): %s\n", req.URL)
+}
+
+func main() {
+	flag.Parse()
+
+	config, configErr := ParseConfig(*configFile)
+	if configErr != nil {
+		log.Printf("%v\n", configErr)
+		os.Exit(1)
+	}
+
+	backends := make(map[string]*httputil.ReverseProxy)
+	for _, route := range config.Routes {
+		target, err := url.Parse(route.Target)
+		if err != nil {
+			log.Fatalf("Error parsing target URL %s: %v\n", route.Target, err)
+		}
+		log.Printf("Redirecting %s -> %s\n", route.Path, route.Target)
+		backends[route.Path] = httputil.NewSingleHostReverseProxy(target)
+	}
+
+	hostPort := fmt.Sprintf("%s:%d", *host, *port)
+	log.Printf("Listening on %s", hostPort)
+
+	proxy := &Proxy{
+		Backends: backends,
+	}
+
+	http.Handle("/", proxy)
+	log.Fatal(http.ListenAndServe(hostPort, nil))
+}


### PR DESCRIPTION
This is a simple Go server which sends requests to backends based on URL
patterns. Essentially, this is a much simpler version of Envoy, implementing a
tiny fraction of its capabilities with some standard libraries provided in Go.

This is enough to route incoming requests either to our web UI server (Node) or
the API server (another Go binary), and would mimic the actual production
deployment if this were done in App Engine or Cloud Run, behind a reverse
proxy which would direct requests similarly based on URL patterns.