### PR TITLE
Fix `golint`-provided warnings

### DIFF
--- a/web/proxy/proxy.go
+++ b/web/proxy/proxy.go
@@ -36,15 +36,18 @@ var (
 	configFile = flag.String("config", "", "Config file, either YAML (*.yaml, *.yml) or JSON (*.json) format.")
 )
 
+// Route represents a single pair (URL path prefix, target).
 type Route struct {
 	Path   string `yaml:"path" json:"path"`
 	Target string `yaml:"target" json:"target"`
 }
 
+// ProxyConfig represents the set of routes for the reverse proxy.
 type ProxyConfig struct {
 	Routes []Route `yaml:"routes" json:"routes"`
 }
 
+// ConfigError is returned while parsing or loading an invalid config.
 type ConfigError struct {
 	Message string
 }
@@ -53,6 +56,8 @@ func (ce *ConfigError) Error() string {
 	return ce.Message
 }
 
+// ParseConfig loads the config stored in the provided file and returns a
+// config object.
 func ParseConfig(filename string) (*ProxyConfig, error) {
 	if filename == "" {
 		return nil, &ConfigError{
@@ -90,6 +95,7 @@ func ParseConfig(filename string) (*ProxyConfig, error) {
 	return config, nil
 }
 
+// Proxy represents the runtime state of the reverse proxy.
 type Proxy struct {
 	Backends map[string]*httputil.ReverseProxy
 }

--- a/web/server/api/api.go
+++ b/web/server/api/api.go
@@ -23,27 +23,35 @@ import (
 	"time"
 )
 
+// Note represents a singular note.
 type Note struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
-	Id    string `json:"id"`
+	ID    string `json:"id"`
 }
 
+// ListNotesResponse is the response type of the ListNotes RPC.
+//
+// There is no parallel ListNotesRequest at this time as the user sends no
+// payload for this RPC.
 type ListNotesResponse struct {
 	Notes []Note `json:"notes"`
 }
 
+// CreateNoteRequest is the request type of the CreateNote RPC.
 type CreateNoteRequest struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
 }
 
+// CreateNoteResponse is the response type of the CreateNote RPC.
 type CreateNoteResponse struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
-	Id    string `json:"id"`
+	ID    string `json:"id"`
 }
 
+// ErrorResponse is a generic error response which may be used in several RPCs.
 type ErrorResponse struct {
 	Error string `json:"error"`
 }
@@ -53,17 +61,17 @@ func listNotes(rw http.ResponseWriter, req *http.Request) {
 		{
 			Title: "Foo",
 			Body:  "Foo note",
-			Id:    "this-is-foo",
+			ID:    "this-is-foo",
 		},
 		{
 			Title: "Bar",
 			Body:  "Bar note",
-			Id:    "this-is-bar",
+			ID:    "this-is-bar",
 		},
 		{
 			Title: "Baz",
 			Body:  "Baz note",
-			Id:    "this-is-baz",
+			ID:    "this-is-baz",
 		},
 	}
 	resp := &ListNotesResponse{
@@ -91,7 +99,7 @@ func createNote(rw http.ResponseWriter, req *http.Request) {
 	createResp := &CreateNoteResponse{
 		Title: createReq.Title,
 		Body:  createReq.Body,
-		Id:    fmt.Sprintf("%d", time.Now().UnixNano()/1000),
+		ID:    fmt.Sprintf("%d", time.Now().UnixNano()/1000),
 	}
 	data, err := json.Marshal(createResp)
 	if err != nil {
@@ -112,6 +120,7 @@ func handleError(rw http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(rw, "%s", data)
 }
 
+// HandleRequest dispatches the incoming request based on URL path.
 func HandleRequest(rw http.ResponseWriter, req *http.Request) {
 	log.Printf("Request [API]: %s %s", req.Method, req.URL.Path)
 	if req.URL.Path == "/api/v1/notes" {

--- a/web/server/db/db.go
+++ b/web/server/db/db.go
@@ -14,17 +14,22 @@
 
 package db
 
+// PartialNote represents a note as may be sent by a user when creating a note,
+// e.g., missing an Id field.
 type PartialNote struct {
 	Title string
 	Body  string
 }
 
+// Note represents a complete note, e.g., as stored in the database.
 type Note struct {
 	Title string
 	Body  string
-	Id    string
+	ID    string
 }
 
+// Database represents a generic abstract storage system, with several
+// potential implementations.
 type Database interface {
 	ListNotes() []Note
 	CreateNote(note PartialNote) (Note, error)

--- a/web/server/db/inmem.go
+++ b/web/server/db/inmem.go
@@ -19,19 +19,24 @@ import (
 	"time"
 )
 
+// InMemoryDatabase is a simgple in-memory storage system for local
+// prototyping, development, and testing. As it is not durable, it's not
+// intended to be used in production.
 type InMemoryDatabase struct {
 	storage []Note
 }
 
+// ListNotes returns all notes stored in the database.
 func (inmem *InMemoryDatabase) ListNotes() []Note {
 	return inmem.storage
 }
 
+// CreateNote creates a note in the in-memory database.
 func (inmem *InMemoryDatabase) CreateNote(note PartialNote) (Note, error) {
 	newNote := Note{
 		Title: note.Title,
 		Body:  note.Body,
-		Id:    fmt.Sprintf("%d", time.Now().UnixNano()/1000),
+		ID:    fmt.Sprintf("%d", time.Now().UnixNano()/1000),
 	}
 	inmem.storage = append(inmem.storage, newNote)
 	return newNote, nil
@@ -45,9 +50,12 @@ func (notFound notFoundError) Error() string {
 	return notFound.message
 }
 
+// DeleteNote deletes the note with the given id from the in-memory database.
+// If the note with such an ID does not exist, or if the deletion request
+// failed for any other reason, an error is returned.
 func (inmem *InMemoryDatabase) DeleteNote(id string) error {
 	for idx, note := range inmem.storage {
-		if note.Id == id {
+		if note.ID == id {
 			inmem.storage = append(inmem.storage[:idx], inmem.storage[idx+1:]...)
 			return nil
 		}
@@ -55,6 +63,7 @@ func (inmem *InMemoryDatabase) DeleteNote(id string) error {
 	return notFoundError{message: fmt.Sprintf("Note id not found: %s", id)}
 }
 
+// CreateInMemoryDatabase returns a new instance of the in-memory database.
 func CreateInMemoryDatabase() *InMemoryDatabase {
 	return &InMemoryDatabase{}
 }

--- a/web/server/db/inmem_test.go
+++ b/web/server/db/inmem_test.go
@@ -40,7 +40,7 @@ func matchPartialNoteAndNote(t *testing.T, expected PartialNote, actual Note) {
 func matchNotes(t *testing.T, expected Note, actual Note) {
 	matchField(t, "Title", expected.Title, actual.Title)
 	matchField(t, "Body", expected.Body, actual.Body)
-	matchField(t, "Id", expected.Id, actual.Id)
+	matchField(t, "ID", expected.ID, actual.ID)
 }
 
 func expectEmpty(t *testing.T, database *InMemoryDatabase) {
@@ -73,7 +73,7 @@ func TestSequence_Add_List_Delete_List(t *testing.T) {
 	matchNotes(t, note, firstNote)
 
 	// Delete the not we added earlier.
-	deleteErr := database.DeleteNote(note.Id)
+	deleteErr := database.DeleteNote(note.ID)
 	if deleteErr != nil {
 		t.Errorf("Error deleting note: %v", deleteErr)
 		return


### PR DESCRIPTION
The Go code is now `golint`-clean; as a result, future warnings will not be
masked behind many other (mostly documentation and field naming) issues.