### PR TITLE
Add basic `manifest.json` with name + description

### DIFF
--- a/web/ui/src/manifest.json
+++ b/web/ui/src/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "Notebook",
+  "short_name": "Notebook",
+  "display": "standalone",
+  "background_color": "#fff",
+  "description": "Notebook helps you organize your information"
+}


### PR DESCRIPTION
Avoid adding image icons for now, but having a valid web manifest enables us to
avoid the errors in the browser console and makes for a much smoother
development experience, as the list queries now reliably work, rather than
being short-circuited because the manifest cannot be parsed (because the server
returns 404 page as HTML instead of a JSON response).