### PR TITLE
Remove duplicate output for redirected URLs

### DIFF
--- a/web/proxy/proxy.go
+++ b/web/proxy/proxy.go
@@ -101,15 +101,14 @@ type Proxy struct {
 }
 
 func (proxy *Proxy) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	log.Printf("Incoming request: %s", req.URL.Path)
 	for path, backend := range proxy.Backends {
 		if strings.HasPrefix(req.URL.Path, path) {
-			log.Printf("Redirecting %s\n", req.URL.Path)
+			log.Printf("%s %s", req.Method, req.URL.Path)
 			backend.ServeHTTP(rw, req)
 			return
 		}
 	}
-	log.Printf("Error: unhandled request (no backend mapping): %s\n", req.URL)
+	log.Printf("Error: unhandled request (no backend mapping): %s %s\n", req.Method, req.URL.Path)
 }
 
 func main() {


### PR DESCRIPTION
When we are redirecting URLs, we are printing the URLs out twice:

* once for the incoming URL request
* once more for redirecting the URL, without any additional info

Replace this with a single line per handled request, and also output the method
with the URL to easily differentiate GET vs. POST requests, for example.

Also add the method to the error messages for unhandled URLs for clarity.