### PR TITLE
Fix setup & run instructions [skip ci]

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -29,6 +29,14 @@ $ go build .
 $ ./server -port 5000
 ```
 
+> Note: if you are seeing errors because port 5000 is in use, or you are getting
+> permission errors when accessing the server on this port, you should be aware
+> that port 5000 is used by Control Center in macOS Monterey for AirPlay.
+>
+> You can either use a different port or [disable
+> AirPlay](https://nono.ma/port-5000-used-by-control-center-in-macos) by
+> unchecking it in "System Preferences › Sharing" if you don't use it.
+
 ### Run the proxy
 
 Download and build the proxy:

--- a/web/README.md
+++ b/web/README.md
@@ -34,25 +34,26 @@ $ ./server -port 5000
 Download and build the proxy:
 
 ```
-$ go get -u github.com/mbrukman/notebook/web/proxy
+$ cd proxy
+$ go build .
 ```
 
-Create config matching the port numbers used above:
+Use the provided [`config.yaml`](proxy/config.yaml) which will use the above
+default ports, or update `config.yaml` locally to suit your needs:
 
 ```
-$ cat > config.yaml <<EOF
+$ tail -5 config.yaml
 routes:
   - path: /api/
     target: http://localhost:5000
   - path: /
     target: http://localhost:8080
-EOF
 ```
 
-Run the proxy with the config we created:
+Run the proxy:
 
 ```
-$ proxy -config config.yml -port 9000
+$ ./proxy -config config.yaml -port 9000
 ```
 
 Now you can access http://localhost:9000 to access the combination of servers


### PR DESCRIPTION
This PR includes two documentation-only commits, which don't require testing:

* Fix API server build & run instructions [skip ci] 
* Add note about port 5000 in macOS [skip ci]