### PR TITLE
Add caching for Node modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,18 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "~/.npm"
+          key: os-${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            os-${{ runner.os }}-node-${{ matrix.node }}-yarn-
+            os-${{ runner.os }}-node-
+            os-${{ runner.os }}-
+
       - name: Install dependencies
         run: cd web/ui && yarn install
 


### PR DESCRIPTION
Following the [example] provided in the GitHub Actions docs.

[example]: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action