### PR TITLE
When caching Bazel artifacts, hash WORKSPACE

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: "~/.cache/bazel"
-          key: bazel-${{ matrix.bazel }}-os-${{ matrix.os }}
+          key: os-${{ runner.os }}-bazel-${{ matrix.bazel }}-workspace-${{ hashFiles('**/WORKSPACE') }}
+          restore-keys: |
+            os-${{ runner.os }}-bazel-${{ matrix.bazel }}-workspace-
+            os-${{ runner.os }}-bazel-
+            os-${{ runner.os }}-
 
       - name: Verify Bazel installation
         run: bazel version


### PR DESCRIPTION
The `WORKSPACE` file can make material changes to the configuration of the Bazel
build, so its contents should be taken into account.

Also add `restore-keys` parameter to match other examples.