### PR TITLE
Update Bazel rules_go from v0.28.0 to v0.30.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,10 +16,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "8e968b5fcea1d2d64071872b12737bbb5514524ee5f0a4f54f5920266c261acb",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.28.0/rules_go-v0.28.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
     ],
 )
 
@@ -58,6 +58,6 @@ go_repository(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.16.5")
+go_register_toolchains(version = "1.17.6")
 
 gazelle_dependencies()


### PR DESCRIPTION
Using the URLs and hashes from the project's README:
https://github.com/bazelbuild/rules_go/#initial-project-setup

Also update Go toolchain from 1.16.5 to 1.17.6