### PR TITLE
Update GitHub Actions to Ubuntu 22.04, macOS 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,12 @@ on:
 
 jobs:
   server:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
         go: [ '1.17', '1.16', '1.15', '1.14', '1.13', '1.12' ]
-    name: Go ${{ matrix.go }}
+        os: [ 'ubuntu-22.04' ]
+    runs-on: ${{ matris.os }}
+    name: Go ${{ matrix.go }} on ${{ matrix.os }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -43,12 +44,12 @@ jobs:
         run: make test VERBOSE=1
 
   server-bazel:
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'macos-10.15', 'ubuntu-20.04' ]
         bazel: [ '4.2.2', '5.0.0' ]
         go: [ '1.17' ]
+        os: [ 'macos-11', 'ubuntu-22.04' ]
+    runs-on: ${{ matrix.os }}
     name: Bazel ${{ matrix.bazel }} and Go ${{ matrix.go }} on ${{ matrix.os }}
     steps:
       - name: Checkout repo
@@ -84,11 +85,12 @@ jobs:
         run: bazel test //...
 
   ui:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node: [ '16', '14', '12' ]
-    name: Node ${{ matrix.node }}
+        os: [ 'ubuntu-22.04' ]
+    runs-on: ${{ matris.os }}
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Specify OS versions via variable using the `matrix` block rather than hardcoding it, so that it's easier to add and remove versions in the future, and reference them in the test job name for easier analysis in the GitHub UI.