### PR TITLE
Move `--openssl-legacy-provider` to package.json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,12 +116,4 @@ jobs:
         run: cd web/ui && yarn install
 
       - name: Build web app
-        env:
-          # https://stackoverflow.com/q/69692842
-          # Addresses the error message:
-          #
-          #     Error message "error:0308010C:digital envelope routines::unsupported"
-          #
-          # that started happening when upgrading to Node v17 or later.
-          NODE_OPTIONS: "--openssl-legacy-provider"
         run: cd web/ui && yarn run build

--- a/web/ui/package.json
+++ b/web/ui/package.json
@@ -6,8 +6,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "build": "preact build",
-    "dev": "preact watch"
+    "build": "NODE_OPTIONS=--openssl-legacy-provider preact build",
+    "dev": "NODE_OPTIONS=--openssl-legacy-provider preact watch"
   },
   "dependencies": {
     "preact": "^10.11.3",


### PR DESCRIPTION
Node v17 and higher report the error message:

> Error message "error:0308010C:digital envelope routines::unsupported"

https://stackoverflow.com/q/69692842 has the solution to add this flag to `NODE_OPTIONS` which we used to fix CI builds when adding Node v18 and v20 in https://github.com/mbrukman/notebook/pull/82

This change moves the flag from the CI config into this command as it's necessary here for interactive development and builds, and the CI will add a copy of the same flag, so as a result, we are avoiding flag duplication.