### PR TITLE
Add `http://` prefix to URLs in console at startup

### DIFF
--- a/web/proxy/proxy.go
+++ b/web/proxy/proxy.go
@@ -131,7 +131,7 @@ func main() {
 	}
 
 	hostPort := fmt.Sprintf("%s:%d", *host, *port)
-	log.Printf("Listening on %s", hostPort)
+	log.Printf("Listening on http://%s", hostPort)
 
 	proxy := &Proxy{
 		Backends: backends,

--- a/web/server/server.go
+++ b/web/server/server.go
@@ -47,6 +47,6 @@ func main() {
 	http.HandleFunc("/", apiHandler.DispatchHandler)
 
 	hostPort := fmt.Sprintf("%s:%s", *host, *port)
-	log.Printf("Listening on %s", hostPort)
+	log.Printf("Listening on http://%s", hostPort)
 	log.Fatal(http.ListenAndServe(hostPort, nil))
 }


### PR DESCRIPTION
This makes the URLs trivially clickable instead of requiring manual copy-pasting in order to open these URLs in a web browser.