### PR TITLE
Split single actions config into per-language

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -12,38 +12,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Build & test"
+name: "Bazel"
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ main ]
+    paths:
+        # Bazel configs
+      - WORKSPACE
+        # Bazel files
+      - '**/BUILD'
+      - '**/*.bazel'
+      - '**/*.bzl'
+        # Go source files
+      - '**/*.go'
+        # Relevant CI configs
+      - '.github/workflows/bazel.yaml' # this file
+
   pull_request:
     branches: [ main ]
+    paths:
+        # Bazel configs
+      - WORKSPACE
+        # Bazel files
+      - '**/BUILD'
+      - '**/*.bazel'
+      - '**/*.bzl'
+        # Go source files
+      - '**/*.go'
+        # Relevant CI configs
+      - '.github/workflows/bazel.yaml' # this file
 
 jobs:
-  server:
-    strategy:
-      matrix:
-        go: [ '1.17', '1.16', '1.15', '1.14', '1.13', '1.12' ]
-        os: [ 'ubuntu-22.04' ]
-    runs-on: ${{ matrix.os }}
-    name: Go ${{ matrix.go }} on ${{ matrix.os }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go }}
-
-      - name: Build
-        run: go build -v ./...
-
-      - name: Run tests
-        run: make test VERBOSE=1
-
-  server-bazel:
+  bazel:
     strategy:
       matrix:
         bazel: [ '4.2.2', '5.0.0' ]
@@ -84,37 +88,3 @@ jobs:
 
       - name: Run tests
         run: bazel test //...
-
-  ui:
-    strategy:
-      matrix:
-        node: [ '20', '18' ]
-        os: [ 'ubuntu-22.04' ]
-    runs-on: ${{ matrix.os }}
-    name: Node ${{ matrix.node }} on ${{ matrix.os }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: "~/.npm"
-          key: os-${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            os-${{ runner.os }}-node-${{ matrix.node }}-yarn-
-            os-${{ runner.os }}-node-
-            os-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: cd web/ui && yarn install
-
-      - name: Build web app
-        run: cd web/ui && yarn run build

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,64 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Go"
+
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
+on:
+  push:
+    branches: [ main ]
+    paths:
+        # Go configs
+      - go.mod
+      - go.sum
+        # Go source files
+      - '**/*.go'
+        # Relevant CI configs
+      - '.github/workflows/go.yaml' # this file
+
+  pull_request:
+    branches: [ main ]
+    paths:
+        # Go configs
+      - go.mod
+      - go.sum
+        # Go source files
+      - '**/*.go'
+        # Relevant CI configs
+      - '.github/workflows/go.yaml' # this file
+
+jobs:
+  go:
+    strategy:
+      matrix:
+        go: [ '1.17', '1.16', '1.15', '1.14', '1.13', '1.12' ]
+        os: [ 'ubuntu-22.04' ]
+    runs-on: ${{ matrix.os }}
+    name: Go ${{ matrix.go }} on ${{ matrix.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Run tests
+        run: make test VERBOSE=1

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -1,0 +1,70 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Node"
+
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
+on:
+  push:
+    branches: [ main ]
+    paths:
+        # Source files
+      - 'web/ui/**'
+        # Relevant CI configs
+      - '.github/workflows/node.yaml' # this file
+
+  pull_request:
+    branches: [ main ]
+    paths:
+        # Source files
+      - 'web/ui/**'
+        # Relevant CI configs
+      - '.github/workflows/node.yaml' # this file
+
+jobs:
+  ui:
+    strategy:
+      matrix:
+        node: [ '20', '18' ]
+        os: [ 'ubuntu-22.04' ]
+    runs-on: ${{ matrix.os }}
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: "~/.npm"
+          key: os-${{ runner.os }}-node-${{ matrix.node }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            os-${{ runner.os }}-node-${{ matrix.node }}-yarn-
+            os-${{ runner.os }}-node-
+            os-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: cd web/ui && yarn install
+
+      - name: Build web app
+        run: cd web/ui && yarn run build

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Notebook
 
-[![Build Status][github-ci-badge]][github-ci-url]
+[![Bazel][bazel-ci-badge]][bazel-ci-url]
+[![Node][node-ci-badge]][node-ci-url]
+[![Go][go-ci-badge]][go-ci-url]
 [![Go docs][go-doc-badge]][go-doc-url]
 [![Go Report Card][go-report-card-badge]][go-report-card-url]
 
-[github-ci-badge]: https://github.com/mbrukman/notebook/actions/workflows/main.yml/badge.svg
-[github-ci-url]: https://github.com/mbrukman/notebook/actions/workflows/main.yml
+[bazel-ci-badge]: https://github.com/mbrukman/notebook/actions/workflows/bazel.yaml/badge.svg
+[bazel-ci-url]: https://github.com/mbrukman/notebook/actions/workflows/bazel.yaml
+[node-ci-badge]: https://github.com/mbrukman/notebook/actions/workflows/node.yaml/badge.svg
+[node-ci-url]: https://github.com/mbrukman/notebook/actions/workflows/node.yaml
+[go-ci-badge]: https://github.com/mbrukman/notebook/actions/workflows/go.yaml/badge.svg
+[go-ci-url]: https://github.com/mbrukman/notebook/actions/workflows/go.yaml
 [go-doc-badge]: http://img.shields.io/badge/godoc-reference-informational.svg
 [go-doc-url]: https://pkg.go.dev/github.com/mbrukman/notebook
 [go-report-card-badge]: https://goreportcard.com/badge/github.com/mbrukman/notebook


### PR DESCRIPTION
Now we have one each for Bazel, Node, and Go, which should only run if files relevant to their builds are modified, so we reduce how often the builds run, and also don't run the builds for updating documentation.