### PR TITLE
Switch Bazel WORKSPACE Go version to "host"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -58,6 +58,6 @@ go_repository(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.17.6")
+go_register_toolchains(version = "host")
 
 gazelle_dependencies()


### PR DESCRIPTION
No need to hard-code a specific version, we can just use the host, which will make it easy for folks to use with any version they have already installed, and makes it easier to specify a different version via GitHub Actions versions dynamically.