### PR TITLE
Switch from setup-bazelisk to setup-bazel

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -68,18 +68,14 @@ jobs:
         with:
           go-version: '${{ matrix.go }}'
 
-      - name: Setup Bazelisk
-        uses: bazelbuild/setup-bazelisk@v2
-
-      - name: Setup cache
-        uses: actions/cache@v4
+      - uses: bazel-contrib/setup-bazel@0.8.1
         with:
-          path: "~/.cache/bazel"
-          key: os-${{ runner.os }}-bazel-${{ matrix.bazel }}-workspace-${{ hashFiles('**/WORKSPACE') }}
-          restore-keys: |
-            os-${{ runner.os }}-bazel-${{ matrix.bazel }}-workspace-
-            os-${{ runner.os }}-bazel-
-            os-${{ runner.os }}-
+          # Avoid downloading Bazel every time.
+          bazelisk-cache: true
+          # Store build cache per workflow.
+          disk-cache: ${{ github.workflow }}
+          # Share repository cache between workflows.
+          repository-cache: true
 
       - name: Verify Bazel installation
         run: bazel version


### PR DESCRIPTION
bazelbuild/setup-bazelisk is deprecated as per the [repo][1]:

> setup-bazelisk has been superseded by setup-bazel and all maintenance and
> support has ceased. setup-bazelisk will remain on GitHub indefinitely, but
> will almost certainly stop working someday, so if your GitHub Actions
> workflows use setup-bazelisk, please migrate them to setup-bazel.

Configuration syntax for setup-bazel taken from its [repo][2].

[1]: https://github.com/bazelbuild/setup-bazelisk?tab=readme-ov-file
[2]: https://github.com/bazel-contrib/setup-bazel?tab=readme-ov-file#usage