### PR TITLE
Remove Bazel versions < 6.0 from GitHub Actions

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bazel: [ '6.0.0', '5.0.0' ]
+        bazel: [ '6.0.0' ]
         go: [ '1.17' ]
         os: [ 'macos-11', 'ubuntu-22.04' ]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Bazel 6.0 is the first version supporting Bzlmod, so this is the first step in upgrading to Bzlmod as per https://github.com/mbrukman/notebook/issues/90

* https://blog.bazel.build/2022/12/19/bazel-6.0.html
* https://bazel.build/versions/6.0.0/build/bzlmod