### PR TITLE
Factor out rules_go and gazelle versions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,21 +14,23 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+rules_go_version = "v0.33.0"
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/{0}/rules_go-{0}.zip".format(rules_go_version),
+        "https://github.com/bazelbuild/rules_go/releases/download/{0}/rules_go-{0}.zip".format(rules_go_version),
     ],
 )
 
+gazelle_version = "v0.25.0"
 http_archive(
     name = "bazel_gazelle",
     sha256 = "5982e5463f171da99e3bdaeff8c0f48283a7a5f396ec5282910b9e8a49c0dd7e",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.25.0/bazel-gazelle-v0.25.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/{0}/bazel-gazelle-{0}.tar.gz".format(gazelle_version),
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/{0}/bazel-gazelle-{0}.tar.gz".format(gazelle_version),
     ],
 )
 


### PR DESCRIPTION
They appear in 4 places for each version; factoring them out into a variable will make it easier to update each of them to more recent versions.

No functional changes.