### PR TITLE
Update macOS 11 to 12 and add monthly cron jobs

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -46,6 +46,17 @@ on:
         # Relevant CI configs
       - '.github/workflows/bazel.yaml' # this file
 
+  schedule:
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+      #
+      #      ┌───────────── minute (0 - 59)
+      #      │ ┌───────────── hour (0 - 23)
+      #      │ │ ┌───────────── day of the month (1 - 31)
+      #      │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+      #      │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+      #      │ │ │ │ │
+    - cron: '1 2 3 * *'  # run at 2:01 every month on the 3rd day
+
 jobs:
   bazel:
     strategy:
@@ -53,7 +64,7 @@ jobs:
       matrix:
         bazel: [ '6.0.0' ]
         go: [ '1.17' ]
-        os: [ 'macos-11', 'ubuntu-22.04' ]
+        os: [ 'macos-12', 'ubuntu-22.04' ]
     runs-on: ${{ matrix.os }}
     name: Bazel ${{ matrix.bazel }} and Go ${{ matrix.go }} on ${{ matrix.os }}
     env:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -40,13 +40,24 @@ on:
         # Relevant CI configs
       - '.github/workflows/go.yaml' # this file
 
+  schedule:
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+      #
+      #      ┌───────────── minute (0 - 59)
+      #      │ ┌───────────── hour (0 - 23)
+      #      │ │ ┌───────────── day of the month (1 - 31)
+      #      │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+      #      │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+      #      │ │ │ │ │
+    - cron: '1 2 3 * *'  # run at 2:01 every month on the 3rd day
+
 jobs:
   go:
     strategy:
       fail-fast: false
       matrix:
         go: [ '1.22', '1.21', '1.20', '1.19', '1.18' ]
-        os: [ 'ubuntu-22.04' ]
+        os: [ 'macos-12', 'ubuntu-22.04' ]
     runs-on: ${{ matrix.os }}
     name: Go ${{ matrix.go }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -34,13 +34,24 @@ on:
         # Relevant CI configs
       - '.github/workflows/node.yaml' # this file
 
+  schedule:
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
+      #
+      #      ┌───────────── minute (0 - 59)
+      #      │ ┌───────────── hour (0 - 23)
+      #      │ │ ┌───────────── day of the month (1 - 31)
+      #      │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+      #      │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+      #      │ │ │ │ │
+    - cron: '1 2 3 * *'  # run at 2:01 every month on the 3rd day
+
 jobs:
   ui:
     strategy:
       fail-fast: false
       matrix:
         node: [ '20', '18' ]
-        os: [ 'macos-11', 'ubuntu-22.04' ]
+        os: [ 'macos-12', 'ubuntu-22.04' ]
     runs-on: ${{ matrix.os }}
     name: Node ${{ matrix.node }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
GitHub Actions is [deprecating][1] macOS 11 images on 2024-06-08, so we want to be prepared ahead of time.

Also, added macOS testing for the Go files so that we can be sure it works there as well.

[1]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories