### PR TITLE
Update GitHub Actions to macOS 13

### DIFF
--- a/.github/workflows/bazel.yaml
+++ b/.github/workflows/bazel.yaml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         bazel: [ '6.0.0' ]
         go: [ '1.17' ]
-        os: [ 'macos-12', 'ubuntu-22.04' ]
+        os: [ 'macos-13', 'ubuntu-22.04' ]
     runs-on: ${{ matrix.os }}
     name: Bazel ${{ matrix.bazel }} and Go ${{ matrix.go }} on ${{ matrix.os }}
     env:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         go: [ '1.22', '1.21', '1.20', '1.19', '1.18' ]
-        os: [ 'macos-12', 'ubuntu-22.04' ]
+        os: [ 'macos-13', 'ubuntu-22.04' ]
     runs-on: ${{ matrix.os }}
     name: Go ${{ matrix.go }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [ '20', '18' ]
-        os: [ 'macos-12', 'ubuntu-22.04' ]
+        os: [ 'macos-13', 'ubuntu-22.04' ]
     runs-on: ${{ matrix.os }}
     name: Node ${{ matrix.node }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
macOS 12 was removed from GitHub Actions.